### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Class (KEYWORD1)
 #######################################
 
-TEWeatherShield			KEYWORD1	TEWeatherShield
+TEWeatherShield	KEYWORD1	TEWeatherShield
 TEWeatherShield_Sensor	KEYWORD1	TEWeatherShield
 
 #######################################
@@ -26,14 +26,14 @@ selectTSD305	KEYWORD2
 #######################################
 
 Sensor_HTU21D	LITERAL1
-Sensor_MS5637	LITERAL1	
+Sensor_MS5637	LITERAL1
 Sensor_MS8607	LITERAL1
 Sensor_TSYS01	LITERAL1
 Sensor_TSD305	LITERAL1
-Sensor_NONE		LITERAL1	
+Sensor_NONE	LITERAL1
 
-HTU21D		LITERAL1
-MS5637		LITERAL1
-MS8607		LITERAL1
-TSYS01		LITERAL1
-TSD305		LITERAL1
+HTU21D	LITERAL1
+MS5637	LITERAL1
+MS8607	LITERAL1
+TSYS01	LITERAL1
+TSD305	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords